### PR TITLE
Stop npm update of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
-    open-pull-requests-limit: 2
+#   - package-ecosystem: 'npm'
+#     directory: '/'
+#     schedule:
+#       interval: 'monthly'
+#     open-pull-requests-limit: 2
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+# See .github/workflows/npm-check-updates.yml
 #   - package-ecosystem: 'npm'
 #     directory: '/'
 #     schedule:


### PR DESCRIPTION
npm-check-updates workflow updates npm dependencies instead of dependabot